### PR TITLE
fix: replace 'serve' by 'server'

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ source ~/.bashrc # ou feche e abra um novo terminal
 ```
 10. Rodar o livebook em sua máquina e acessar o link que ele vai lhe dar no navegador.
 ```
-livebook serve
+livebook server
 ```
  
 </details>


### PR DESCRIPTION
## O que foi feito?

Ao final da documentação de instalação no Linux, o último comando está escrito:

```elixir
livebook serve
```

Este PR corrige para:

```elixir
livebook server
```