### PR TITLE
fix the filter param for map comprehension example

### DIFF
--- a/chapters/chapter3.livemd
+++ b/chapters/chapter3.livemd
@@ -338,7 +338,7 @@ Exemplo:
 
 ```elixir
 mapa = %{"a" => 1, "b" => 2, "c" => 3}
-triplica_valores = for {chave, valor} <- mapa, do: {chave, valor * 3}
+triplica_valores = for {chave, valor} <- mapa, into: %{}, do: {chave, valor * 3}
 ```
 
 ## Compreensões Aninhadas


### PR DESCRIPTION
the example of map comprehension has an error I think the return of comprehension should be a map but in the example shown the return is a list of tuples